### PR TITLE
Add ClassWithNullable to demonstrate NRE when call GetHashCode

### DIFF
--- a/AssemblyToProcess/AssemblyToProcess.csproj
+++ b/AssemblyToProcess/AssemblyToProcess.csproj
@@ -41,6 +41,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.cs" />
+    <Compile Include="ClassWithNullable.cs" />
     <Compile Include="CustomEquals.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/AssemblyToProcess/ClassWithNullable.cs
+++ b/AssemblyToProcess/ClassWithNullable.cs
@@ -1,0 +1,7 @@
+﻿using System;
+
+[Equals]
+public class ClassWithNullable
+{
+    public DateTime? NullableDate { get; set; }
+}

--- a/Tests/IntegrationTests.cs
+++ b/Tests/IntegrationTests.cs
@@ -272,6 +272,18 @@ public class IntegrationTests
     }
 
     [Test]
+    public void GetHashCode_should_return_value_for_null_nullable()
+    {
+        var type = assembly.GetType("ClassWithNullable");
+        dynamic instance = Activator.CreateInstance(type);
+        instance.NullableDate = null;
+
+        var result = instance.GetHashCode();
+
+        Assert.AreEqual(0, result);
+    }
+
+    [Test]
     public void GetHashCode_should_return_diffrent_value_for_changed_property_in_base_class()
     {
         var type = assembly.GetType("InheritedClass");
@@ -484,7 +496,7 @@ public class IntegrationTests
 
         Assert.AreNotEqual(0, result);
     }
-    
+
     #endregion
 
     #region Equals


### PR DESCRIPTION
Add ClassWithNullable to demonstrate NRE when call GetHashCode and nullable property is null
