### PR TITLE
FodyCecil update to version 2.0.0

### DIFF
--- a/AssemblyToReference/AssemblyToReference.csproj
+++ b/AssemblyToReference/AssemblyToReference.csproj
@@ -42,9 +42,6 @@
   </PropertyGroup>
   <ItemGroup>
     <None Include="Key.snk" />
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>
@@ -59,9 +56,6 @@
     <Compile Include="TypeCheck.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="FodyWeavers.xml" />
-  </ItemGroup>
-  <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
       <Visible>False</Visible>
       <ProductName>.NET Framework 3.5 SP1 Client Profile</ProductName>
@@ -74,11 +68,4 @@
     </BootstrapperPackage>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
-  <Import Project="..\packages\Fody.1.29.4\build\portable-net+sl+win+wpa+wp\Fody.targets" Condition="Exists('..\packages\Fody.1.29.4\build\portable-net+sl+win+wpa+wp\Fody.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Fody.1.29.4\build\portable-net+sl+win+wpa+wp\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.1.29.4\build\portable-net+sl+win+wpa+wp\Fody.targets'))" />
-  </Target>
 </Project>

--- a/AssemblyToReference/FodyWeavers.xml
+++ b/AssemblyToReference/FodyWeavers.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Weavers>
-  <Stamp />
-</Weavers>

--- a/AssemblyToReference/packages.config
+++ b/AssemblyToReference/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Fody" version="1.29.4" targetFramework="portable-net40+sl50+win+wp80" developmentDependency="true" />
-  <package id="Stamp.Fody" version="1.2.5" targetFramework="portable-net40+sl50+win+wp80" />
-</packages>

--- a/CommonAssemblyInfo.cs
+++ b/CommonAssemblyInfo.cs
@@ -1,5 +1,5 @@
 ﻿using System.Reflection;
 [assembly: AssemblyTitle("Fody.Equals")]
 [assembly: AssemblyProduct("Fody.Equals")]
-[assembly: AssemblyVersion("1.6.2")]
-[assembly: AssemblyFileVersion("1.6.2")]
+[assembly: AssemblyVersion("1.7.0")]
+[assembly: AssemblyFileVersion("1.7.0")]

--- a/Fody/Extensions/CollectionVariableDefinitionExtension.cs
+++ b/Fody/Extensions/CollectionVariableDefinitionExtension.cs
@@ -6,9 +6,9 @@ namespace Equals.Fody.Extensions
 {
     public static class CollectionVariableDefinitionExtension
     {
-        public static VariableDefinition Add(this Collection<VariableDefinition> variables, string name, TypeReference type)
+        public static VariableDefinition Add(this Collection<VariableDefinition> variables, TypeReference type)
         {
-            var variable = new VariableDefinition(name, type);
+            var variable = new VariableDefinition(type);
             variables.Add(variable);
             return variable;
         }

--- a/Fody/Extensions/TypeDefinitionExtensions.cs
+++ b/Fody/Extensions/TypeDefinitionExtensions.cs
@@ -15,7 +15,7 @@ namespace Equals.Fody.Extensions
 
         public static bool IsCollection(this TypeDefinition type)
         {
-            return !type.Name.Equals("String") && (type.Interfaces.Any(i => i.Name.Equals("IEnumerable")));
+            return !type.Name.Equals("String") && (type.Interfaces.Any(i => i.InterfaceType.Name.Equals("IEnumerable")));
         }
 
         public static PropertyDefinition[] GetPropertiesWithoutIgnores(this TypeDefinition type, string ignoreAttributeName)

--- a/Fody/Fody.csproj
+++ b/Fody/Fody.csproj
@@ -46,17 +46,17 @@
   </PropertyGroup>
   <ItemGroup>
     <None Include="packages.config" />
-    <Reference Include="Mono.Cecil">
-      <HintPath>..\packages\FodyCecil.1.29.4\lib\net40\Mono.Cecil.dll</HintPath>
+    <Reference Include="Mono.Cecil, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\FodyCecil.2.0.0\lib\net40\Mono.Cecil.dll</HintPath>
     </Reference>
-    <Reference Include="Mono.Cecil.Mdb">
-      <HintPath>..\packages\FodyCecil.1.29.4\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
+    <Reference Include="Mono.Cecil.Mdb, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\FodyCecil.2.0.0\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
     </Reference>
-    <Reference Include="Mono.Cecil.Pdb">
-      <HintPath>..\packages\FodyCecil.1.29.4\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
+    <Reference Include="Mono.Cecil.Pdb, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\FodyCecil.2.0.0\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
     </Reference>
-    <Reference Include="Mono.Cecil.Rocks">
-      <HintPath>..\packages\FodyCecil.1.29.4\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
+    <Reference Include="Mono.Cecil.Rocks, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\FodyCecil.2.0.0\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -82,15 +82,5 @@
     <Compile Include="ReferenceFinder.cs" />
     <Compile Include="WeavingException.cs" />
   </ItemGroup>
-  <ItemGroup>
-    <Content Include="FodyWeavers.xml" />
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Fody.1.29.4\build\portable-net+sl+win+wpa+wp\Fody.targets" Condition="Exists('..\packages\Fody.1.29.4\build\portable-net+sl+win+wpa+wp\Fody.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Fody.1.29.4\build\portable-net+sl+win+wpa+wp\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.1.29.4\build\portable-net+sl+win+wpa+wp\Fody.targets'))" />
-  </Target>
 </Project>

--- a/Fody/FodyWeavers.xml
+++ b/Fody/FodyWeavers.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Weavers>
-  <Stamp />
-</Weavers>

--- a/Fody/Injectors/CollectionHelperInjector.cs
+++ b/Fody/Injectors/CollectionHelperInjector.cs
@@ -42,10 +42,10 @@ namespace Equals.Fody.Injectors
 
             body.InitLocals = true;
 
-            var leftEnumerator = body.Variables.Add("enumerator", ReferenceFinder.IEnumerator.TypeReference);
-            var rightEnumerator = body.Variables.Add("rightEnumerator", ReferenceFinder.IEnumerator.TypeReference);
-            var leftHasNext = body.Variables.Add("hasNext", ReferenceFinder.Boolean.TypeReference);
-            var rightHasNext = body.Variables.Add("rightHasNext", ReferenceFinder.Boolean.TypeReference);
+            var leftEnumerator = body.Variables.Add(ReferenceFinder.IEnumerator.TypeReference);
+            var rightEnumerator = body.Variables.Add(ReferenceFinder.IEnumerator.TypeReference);
+            var leftHasNext = body.Variables.Add(ReferenceFinder.Boolean.TypeReference);
+            var rightHasNext = body.Variables.Add(ReferenceFinder.Boolean.TypeReference);
 
             AddLeftAndRightReferenceEquals(ins, left, right);
             AddLeftAndNullReferenceEquals(ins, left);

--- a/Fody/Injectors/EqualsInjector.cs
+++ b/Fody/Injectors/EqualsInjector.cs
@@ -44,7 +44,7 @@ namespace Equals.Fody.Injectors
 
             var body = method.Body;
             body.InitLocals = true;
-            var result = body.Variables.Add("result", ReferenceFinder.Boolean.TypeReference);
+            var result = body.Variables.Add(ReferenceFinder.Boolean.TypeReference);
 
             var ins = body.Instructions;
 
@@ -185,7 +185,7 @@ namespace Equals.Fody.Injectors
                     }
                     else
                     {
-                        var argVariable = body.Variables.Add("argVariable", resolverType);
+                        var argVariable = body.Variables.Add(resolverType);
                         ins.Add(Instruction.Create(OpCodes.Ldarg_0));
                         ins.Add(Instruction.Create(OpCodes.Stloc, argVariable));
 

--- a/Fody/Injectors/GetHashCodeInjector.cs
+++ b/Fody/Injectors/GetHashCodeInjector.cs
@@ -21,7 +21,7 @@ namespace Equals.Fody.Injectors
             var method = new MethodDefinition("GetHashCode", methodAttributes, ReferenceFinder.Int32.TypeReference);
             method.CustomAttributes.MarkAsGeneratedCode();
 
-            var resultVariable = method.Body.Variables.Add("result", ReferenceFinder.Int32.TypeReference);
+            var resultVariable = method.Body.Variables.Add(ReferenceFinder.Int32.TypeReference);
 
             var body = method.Body;
             body.InitLocals = true;
@@ -277,8 +277,8 @@ namespace Equals.Fody.Injectors
             MethodDefinition method, TypeDefinition type, Collection<Instruction> t)
         {
             LoadVariable(property, t, type);
-            var enumeratorVariable = method.Body.Variables.Add(property.Name + "Enumerator", ReferenceFinder.IEnumerator.TypeReference);
-            var currentVariable = method.Body.Variables.Add(property.Name + "Current", ReferenceFinder.Object.TypeReference);
+            var enumeratorVariable = method.Body.Variables.Add(ReferenceFinder.IEnumerator.TypeReference);
+            var currentVariable = method.Body.Variables.Add(ReferenceFinder.Object.TypeReference);
 
             GetEnumerator(t, enumeratorVariable, property);
 

--- a/Fody/ModuleWeaver.cs
+++ b/Fody/ModuleWeaver.cs
@@ -72,9 +72,9 @@ public class ModuleWeaver
                 EqualsInjector.InjectEqualsObject(type, typeRef, newEquals, typeCheck);
 
                 var typeInterface = ReferenceFinder.IEquatable.TypeReference.MakeGenericInstanceType(typeRef);
-                if (type.Interfaces.All(x => x.FullName != typeInterface.FullName))
+                if (type.Interfaces.All(x => x.InterfaceType.FullName != typeInterface.FullName))
                 {
-                    type.Interfaces.Add(typeInterface);
+                    type.Interfaces.Add(new InterfaceImplementation(typeInterface));
                 }
             }
 

--- a/Fody/ReferenceFinder.cs
+++ b/Fody/ReferenceFinder.cs
@@ -91,16 +91,16 @@ namespace Equals.Fody
 
         public static void FindReferences(IAssemblyResolver assemblyResolver)
         {
-            var baseLib = assemblyResolver.Resolve("mscorlib");
+            var baseLib = assemblyResolver.Resolve(new AssemblyNameReference("mscorlib", null));
             var baseLibTypes = baseLib.MainModule.Types;
 
-            var systemLib = assemblyResolver.Resolve("System");
+            var systemLib = assemblyResolver.Resolve(new AssemblyNameReference("System", null));
             var systemLibTypes = systemLib.MainModule.Types;
 
             var winrt = baseLibTypes.All(type => type.Name != "Object");
             if (winrt)
             {
-                baseLib = assemblyResolver.Resolve("System.Runtime");
+                baseLib = assemblyResolver.Resolve(new AssemblyNameReference("System.Runtime", null));
                 baseLibTypes = baseLib.MainModule.Types;
             }
 
@@ -135,7 +135,7 @@ namespace Equals.Fody
             var generatedCodeType = systemLibTypes.FirstOrDefault(t => t.Name == "GeneratedCodeAttribute");
             if (generatedCodeType == null)
             {
-                var systemDiagnosticsTools = assemblyResolver.Resolve("System.Diagnostics.Tools");
+                var systemDiagnosticsTools = assemblyResolver.Resolve(new AssemblyNameReference("System.Diagnostics.Tools", null));
                 generatedCodeType = systemDiagnosticsTools.MainModule.Types.First(t => t.Name == "GeneratedCodeAttribute");
             }
             GeneratedCodeAttribute.TypeReference = moduleDefinition.ImportReference(generatedCodeType);
@@ -144,7 +144,7 @@ namespace Equals.Fody
             var debuggerNonUserCodeType = baseLibTypes.FirstOrDefault(t => t.Name == "DebuggerNonUserCodeAttribute");
             if (debuggerNonUserCodeType == null)
             {
-                var systemDiagnosticsDebug = assemblyResolver.Resolve("System.Diagnostics.Debug");
+                var systemDiagnosticsDebug = assemblyResolver.Resolve(new AssemblyNameReference("System.Diagnostics.Debug", null));
                 debuggerNonUserCodeType = systemDiagnosticsDebug.MainModule.Types.First(t => t.Name == "DebuggerNonUserCodeAttribute");
             }
             DebuggerNonUserCodeAttribute.TypeReference = moduleDefinition.ImportReference(debuggerNonUserCodeType);

--- a/Fody/packages.config
+++ b/Fody/packages.config
@@ -1,6 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Fody" version="1.29.4" targetFramework="net45" developmentDependency="true" />
-  <package id="FodyCecil" version="1.29.4" targetFramework="net45" developmentDependency="true" />
-  <package id="Stamp.Fody" version="1.2.5" targetFramework="net45" />
+  <package id="FodyCecil" version="2.0.0" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/NuGet/Equals.Fody.nuspec
+++ b/NuGet/Equals.Fody.nuspec
@@ -15,7 +15,7 @@
     <language>en-UK</language>
     <tags>Equals, GetHashCode, Operators, ILWeaving, Fody, Cecil</tags>
     <dependencies>
-      <dependency id="Fody" version="1.29.2"/>
+      <dependency id="Fody" version="[2.0.0, 3.0.0)"/>
     </dependencies>
   </metadata>
 </package>

--- a/Tests/IntegrationTests.cs
+++ b/Tests/IntegrationTests.cs
@@ -29,18 +29,20 @@ public partial class IntegrationTests
             {
                 Directory = Path.GetDirectoryName(beforeAssemblyPath)
             };
-        var moduleDefinition = ModuleDefinition.ReadModule(afterAssemblyPath,new ReaderParameters
+        var readerParameters = new ReaderParameters
             {
                 AssemblyResolver = assemblyResolver
-            });
-        var weavingTask = new ModuleWeaver
-                              {
-                                  ModuleDefinition = moduleDefinition,
-                                  AssemblyResolver = assemblyResolver,
-                              };
+            };
+        using (var moduleDefinition = ModuleDefinition.ReadModule(beforeAssemblyPath, readerParameters)) {
+            var weavingTask = new ModuleWeaver
+                {
+                    ModuleDefinition = moduleDefinition,
+                    AssemblyResolver = assemblyResolver
+                };
 
-        weavingTask.Execute();
-        moduleDefinition.Write(afterAssemblyPath);
+            weavingTask.Execute();
+            moduleDefinition.Write(afterAssemblyPath);
+        }
 
         assembly = Assembly.LoadFile(afterAssemblyPath);
     }

--- a/Tests/MockAssemblyResolver.cs
+++ b/Tests/MockAssemblyResolver.cs
@@ -13,17 +13,15 @@ public class MockAssemblyResolver : IAssemblyResolver
         {
             return AssemblyDefinition.ReadAssembly(fileName);
         }
-        var codeBase = Assembly.Load(name.FullName).CodeBase.Replace("file:///", "");
-        return AssemblyDefinition.ReadAssembly(codeBase);
+        return Resolve(name.Name);
     }
 
     public AssemblyDefinition Resolve(AssemblyNameReference name, ReaderParameters parameters)
     {
-
         throw new NotImplementedException();
     }
 
-    public AssemblyDefinition Resolve(string fullName)
+    AssemblyDefinition Resolve(string fullName)
     {
         string codeBase;
         if (fullName == "System")
@@ -39,9 +37,8 @@ public class MockAssemblyResolver : IAssemblyResolver
         return AssemblyDefinition.ReadAssembly(file);
     }
 
-    public AssemblyDefinition Resolve(string fullName, ReaderParameters parameters)
+    public void Dispose()
     {
-        throw new NotImplementedException();
     }
 
     public string Directory;

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -35,21 +35,20 @@
   <ItemGroup>
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Mono.Cecil">
-      <HintPath>..\packages\FodyCecil.1.29.4\lib\net40\Mono.Cecil.dll</HintPath>
+    <Reference Include="Mono.Cecil, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\FodyCecil.2.0.0\lib\net40\Mono.Cecil.dll</HintPath>
     </Reference>
-    <Reference Include="Mono.Cecil.Mdb">
-      <HintPath>..\packages\FodyCecil.1.29.4\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
+    <Reference Include="Mono.Cecil.Mdb, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\FodyCecil.2.0.0\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
     </Reference>
-    <Reference Include="Mono.Cecil.Pdb">
-      <HintPath>..\packages\FodyCecil.1.29.4\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
+    <Reference Include="Mono.Cecil.Pdb, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\FodyCecil.2.0.0\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
     </Reference>
-    <Reference Include="Mono.Cecil.Rocks">
-      <HintPath>..\packages\FodyCecil.1.29.4\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
+    <Reference Include="Mono.Cecil.Rocks, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\FodyCecil.2.0.0\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.4.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.4.1\lib\net45\nunit.framework.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Tests/packages.config
+++ b/Tests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FodyCecil" version="1.29.4" targetFramework="net45" developmentDependency="true" />
-  <package id="NUnit" version="3.4.1" targetFramework="net45" />
+  <package id="FodyCecil" version="2.0.0" targetFramework="net45" developmentDependency="true" />
+  <package id="NUnit" version="3.6.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Update of FodyCecil to be compatible with Fody 2.0.0.
So Equals.Fody can be used with Mono 5.0 (Fody < 2.0 throws an out of memory exception with this version).