### PR TITLE
Fix #99: Using woven `==` or `!=` operator results in build failure

### DIFF
--- a/AssemblyToProcess/NormalClass.cs
+++ b/AssemblyToProcess/NormalClass.cs
@@ -1,4 +1,4 @@
-﻿[Equals]
+﻿[Equals(DoNotAddEqualityOperators = true)]
 public class NormalClass
 {
     public int X { get; set; }
@@ -11,4 +11,24 @@ public class NormalClass
 
     public static bool operator ==(NormalClass left, NormalClass right) => Operator.Weave();
     public static bool operator !=(NormalClass left, NormalClass right) => Operator.Weave();
+}
+
+/// Reproducing https://github.com/Fody/Equals/issues/99
+public class UsingNormalClass
+{
+    public bool CompareNormalClassForEquality()
+    {
+        var left = new NormalClass();
+        var right = new NormalClass();
+
+        return left == right;
+    }
+
+    public bool CompareNormalClassForInequality()
+    {
+        var left = new NormalClass();
+        var right = new NormalClass();
+
+        return left != right;
+    }
 }

--- a/AssemblyToProcess/NormalClass.cs
+++ b/AssemblyToProcess/NormalClass.cs
@@ -1,4 +1,4 @@
-﻿[Equals(DoNotAddEqualityOperators = true)]
+﻿[Equals]
 public class NormalClass
 {
     public int X { get; set; }

--- a/AssemblyToProcess/NormalClass.cs
+++ b/AssemblyToProcess/NormalClass.cs
@@ -12,23 +12,3 @@ public class NormalClass
     public static bool operator ==(NormalClass left, NormalClass right) => Operator.Weave();
     public static bool operator !=(NormalClass left, NormalClass right) => Operator.Weave();
 }
-
-/// Reproducing https://github.com/Fody/Equals/issues/99
-public class UsingNormalClass
-{
-    public bool CompareNormalClassForEquality()
-    {
-        var left = new NormalClass();
-        var right = new NormalClass();
-
-        return left == right;
-    }
-
-    public bool CompareNormalClassForInequality()
-    {
-        var left = new NormalClass();
-        var right = new NormalClass();
-
-        return left != right;
-    }
-}

--- a/AssemblyToProcess/OnlyOperator.cs
+++ b/AssemblyToProcess/OnlyOperator.cs
@@ -16,3 +16,23 @@ public class OnlyOperator
     public static bool operator ==(OnlyOperator left, OnlyOperator right) => Operator.Weave();
     public static bool operator !=(OnlyOperator left, OnlyOperator right) => Operator.Weave();
 }
+
+/// Reproducing https://github.com/Fody/Equals/issues/99
+public class UsingOnlyOperator
+{
+    public bool CompareNormalClassForEquality()
+    {
+        var left = new UsingOnlyOperator();
+        var right = new UsingOnlyOperator();
+
+        return left == right;
+    }
+
+    public bool CompareNormalClassForInequality()
+    {
+        var left = new UsingOnlyOperator();
+        var right = new UsingOnlyOperator();
+
+        return left != right;
+    }
+}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,6 +3,6 @@
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
-    <Version>3.0.0</Version>
+    <Version>3.0.1</Version>
   </PropertyGroup>
 </Project>

--- a/Equals.Fody/Injectors/OperatorInjector.cs
+++ b/Equals.Fody/Injectors/OperatorInjector.cs
@@ -5,26 +5,19 @@ using Mono.Collections.Generic;
 
 public partial class ModuleWeaver
 {
-    public void InjectOperator(TypeDefinition type, Operator @operator)
+    public void ReplaceOperator(TypeDefinition type, Operator @operator)
     {
-        var methodAttributes = MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.SpecialName | MethodAttributes.Static;
-        var method = new MethodDefinition(@operator.MethodName, methodAttributes, TypeSystem.BooleanReference);
+        var method = WeavingInstruction.RetrieveOperatorAndAssertHasWeavingInstruction(type, @operator);
         MarkAsGeneratedCode(method.CustomAttributes);
-
-        var parameterType = type.GetGenericInstanceType(type);
-
-        method.Parameters.Add("left", parameterType);
-        method.Parameters.Add("right", parameterType);
 
         var body = method.Body;
         var ins = body.Instructions;
+        ins.Clear();
 
         AddStaticEqualsCall(type, ins);
         ins.AddReturnValue(@operator.IsEquality);
 
         body.OptimizeMacros();
-
-        type.Methods.AddOrReplace(method);
     }
 
     void AddStaticEqualsCall(TypeDefinition type, Collection<Instruction> ins)

--- a/Equals.Fody/ModuleWeaver.cs
+++ b/Equals.Fody/ModuleWeaver.cs
@@ -79,14 +79,13 @@ public partial class ModuleWeaver :
 
             if (IsPropertySet(attribute, DoNotAddEqualityOperators))
             {
-                WeavingInstruction.AssertNotHasWeavingInstruction(type);
+                WeavingInstruction.AssertNotHasWeavingInstruction(type, Operator.Equality);
+                WeavingInstruction.AssertNotHasWeavingInstruction(type, Operator.Inequality);
             }
             else
             {
-                WeavingInstruction.AssertHasWeavingInstruction(type);
-
-                InjectOperator(type, Operator.Equality);
-                InjectOperator(type, Operator.Inequality);
+                ReplaceOperator(type, Operator.Equality);
+                ReplaceOperator(type, Operator.Inequality);
             }
         }
 

--- a/Equals.Fody/WeavingInstruction.cs
+++ b/Equals.Fody/WeavingInstruction.cs
@@ -14,13 +14,7 @@ public class WeavingInstruction
         this.weaveMethod = weaveMethod;
     }
 
-    public void AssertHasWeavingInstruction(TypeDefinition type)
-    {
-        AssertHasWeavingInstruction(type, Operator.Equality);
-        AssertHasWeavingInstruction(type, Operator.Inequality);
-    }
-
-    void AssertHasWeavingInstruction(TypeDefinition type, Operator @operator)
+    public MethodDefinition RetrieveOperatorAndAssertHasWeavingInstruction(TypeDefinition type, Operator @operator)
     {
         if (!@operator.TryGetOperator(type, out var operatorMethod))
         {
@@ -33,15 +27,11 @@ public class WeavingInstruction
             throw CreateException(
                 $"TType {type.Name} marked with the [Equals] attribute contains {@operator.MethodName}, but it does not contain the instruction to weave it. Either set implement the method like {@operator.MethodSourceExample} or, if you don't want the operator to be woven: set `[Equals].DoNotAddEqualityOperators = true`.");
         }
+
+        return operatorMethod;
     }
 
-    public void AssertNotHasWeavingInstruction(TypeDefinition type)
-    {
-        AssertNotHasWeavingInstruction(type, Operator.Equality);
-        AssertNotHasWeavingInstruction(type, Operator.Inequality);
-    }
-
-    void AssertNotHasWeavingInstruction(TypeDefinition type, Operator @operator)
+    public void AssertNotHasWeavingInstruction(TypeDefinition type, Operator @operator)
     {
         if (@operator.TryGetOperator(type, out var operatorMethod))
         {

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,8 @@ The `!=` and `==` operators are not weaved fully automatically anymore. Instead,
     
 **or** opt out of operator weaving by `[Equals(DoNotAddEqualityOperators = true)]`.
 
+Note: With version 3.0.0 operator weaving is buggy. If you experience build errors like ` 'System.Boolean op_Equality(T ,T)' is declared in another module and needs to be imported` or ` 'System.Boolean op_Inequality(T ,T)' is declared in another module and needs to be imported`, make sure to update to version 3.0.1 or above.
+
 ## This is an add-in for [Fody](https://github.com/Fody/Home/)
 
 ![Icon](https://raw.githubusercontent.com/Fody/Equals/master/package_icon.png)


### PR DESCRIPTION
#### Description

Fixes #99 


#### The solution

Replace the existing operator's instructions instead of removing the operator `MethodDefinition` and re-adding a new one.
See [OperatorInjector.cs ReplaceOperator(..)](https://github.com/Fody/Equals/pull/100/files#diff-46ccad49c6960cf3bc572783595e5014R8)

#### Todos

 * [x] Related issues (#99)
 * [x] Tests
 * [x] Documentation (documented in Readme.md, instructed to update to >= 3.0.1)