### PR TITLE
Fix #103: When Equals assembly is unused build fails with an exception

### DIFF
--- a/AssemblyToProcessWithoutReference/AssemblyToProcessWithoutReference.csproj
+++ b/AssemblyToProcessWithoutReference/AssemblyToProcessWithoutReference.csproj
@@ -6,7 +6,6 @@
     <DisableFody>true</DisableFody>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Equals\Equals.csproj" />
     <ProjectReference Include="..\ReferencedDependency\ReferencedDependency.csproj" />
   </ItemGroup>
 </Project>

--- a/AssemblyToProcessWithoutReference/AssemblyToProcessWithoutReference.csproj
+++ b/AssemblyToProcessWithoutReference/AssemblyToProcessWithoutReference.csproj
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
+    <NoWarn>CS0659;CS0660;CS0661</NoWarn>
+    <DisableFody>true</DisableFody>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Equals\Equals.csproj" />
+    <ProjectReference Include="..\ReferencedDependency\ReferencedDependency.csproj" />
+  </ItemGroup>
+</Project>

--- a/AssemblyToProcessWithoutReference/Foo.cs
+++ b/AssemblyToProcessWithoutReference/Foo.cs
@@ -1,6 +1,3 @@
-﻿namespace AssemblyToProcessWithoutReference
+﻿public class Foo
 {
-    public class Foo
-    {
-    }
 }

--- a/AssemblyToProcessWithoutReference/Foo.cs
+++ b/AssemblyToProcessWithoutReference/Foo.cs
@@ -1,0 +1,6 @@
+﻿namespace AssemblyToProcessWithoutReference
+{
+    public class Foo
+    {
+    }
+}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,6 +3,6 @@
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
-    <Version>3.0.1</Version>
+    <Version>3.0.2</Version>
   </PropertyGroup>
 </Project>

--- a/Equals.Fody/ModuleWeaver.cs
+++ b/Equals.Fody/ModuleWeaver.cs
@@ -35,7 +35,11 @@ public partial class ModuleWeaver :
 
     public override void Execute()
     {
-        FindReferences(FindType);
+        if (!FindReferencesAndDetermineWhetherEqualsIsReferenced(FindType))
+        {
+            LogDebug($"Assembly does not reference 'Equals' assembly. No work to do - exiting.");
+            return;
+        }
 
         var collectionEquals = InjectCollectionEquals(ModuleDefinition);
 

--- a/Equals.Fody/ReferenceFinder.cs
+++ b/Equals.Fody/ReferenceFinder.cs
@@ -23,7 +23,7 @@ public partial class ModuleWeaver
 
     public WeavingInstruction WeavingInstruction;
 
-    public void FindReferences(Func<string, TypeDefinition> typeFinder)
+    public bool FindReferencesAndDetermineWhetherEqualsIsReferenced(Func<string, TypeDefinition> typeFinder)
     {
         var typeDefinition = typeFinder("System.Type");
         GetTypeFromHandle = ModuleDefinition.ImportReference(typeDefinition.FindMethod("GetTypeFromHandle", "RuntimeTypeHandle"));
@@ -50,11 +50,18 @@ public partial class ModuleWeaver
         var debuggerNonUserCodeType = typeFinder("System.Diagnostics.DebuggerNonUserCodeAttribute");
         DebuggerNonUserCodeAttributeConstructor = ModuleDefinition.ImportReference(debuggerNonUserCodeType.FindMethod(".ctor"));
 
-        var equalsAssemblyReference = ModuleDefinition.AssemblyReferences.Single(x => x.Name == "Equals");
+        var equalsAssemblyReference = ModuleDefinition.AssemblyReferences.SingleOrDefault(x => x.Name == "Equals");
+        if (equalsAssemblyReference == null)
+        {
+            return false;
+        }
+
         var equalsAssembly = ModuleDefinition.AssemblyResolver.Resolve(equalsAssemblyReference);
         var operatorType = equalsAssembly.MainModule.Types.Single(x => x.Name == "Operator");
         var weaveMethod = operatorType.Methods.Single(x => x.Name == "Weave");
 
         WeavingInstruction = new WeavingInstruction(weaveMethod);
+
+        return true;
     }
 }

--- a/Equals.sln
+++ b/Equals.sln
@@ -7,6 +7,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Equals.Fody", "Equals.Fody\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tests", "Tests\Tests.csproj", "{5A86453B-96FB-4B6E-A283-225BB9F753D3}"
 	ProjectSection(ProjectDependencies) = postProject
+		{7C9B9E2C-E927-46FD-8723-8072747C0873} = {7C9B9E2C-E927-46FD-8723-8072747C0873}
 		{FECCFB62-75B0-4BCD-8919-290FBE97E1C7} = {FECCFB62-75B0-4BCD-8919-290FBE97E1C7}
 		{2388E87C-D5D9-45EE-ABA9-CE4634F5853C} = {2388E87C-D5D9-45EE-ABA9-CE4634F5853C}
 		{2DACC286-3204-4E5D-9873-B8314AF76CBC} = {2DACC286-3204-4E5D-9873-B8314AF76CBC}
@@ -43,6 +44,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ClassWithoutOperators", "BadCaseAssembliesToProcess\ClassWithoutOperators\ClassWithoutOperators.csproj", "{2DACC286-3204-4E5D-9873-B8314AF76CBC}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StructWithoutOperators", "BadCaseAssembliesToProcess\StructWithoutOperators\StructWithoutOperators.csproj", "{2F0DD0E5-35A4-4DF2-825F-F906F31E8462}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AssemblyToProcessWithoutReference", "AssemblyToProcessWithoutReference\AssemblyToProcessWithoutReference.csproj", "{7C9B9E2C-E927-46FD-8723-8072747C0873}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -132,6 +135,14 @@ Global
 		{2F0DD0E5-35A4-4DF2-825F-F906F31E8462}.Release|Any CPU.Build.0 = Release|Any CPU
 		{2F0DD0E5-35A4-4DF2-825F-F906F31E8462}.Release|x86.ActiveCfg = Release|Any CPU
 		{2F0DD0E5-35A4-4DF2-825F-F906F31E8462}.Release|x86.Build.0 = Release|Any CPU
+		{7C9B9E2C-E927-46FD-8723-8072747C0873}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7C9B9E2C-E927-46FD-8723-8072747C0873}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7C9B9E2C-E927-46FD-8723-8072747C0873}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7C9B9E2C-E927-46FD-8723-8072747C0873}.Debug|x86.Build.0 = Debug|Any CPU
+		{7C9B9E2C-E927-46FD-8723-8072747C0873}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7C9B9E2C-E927-46FD-8723-8072747C0873}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7C9B9E2C-E927-46FD-8723-8072747C0873}.Release|x86.ActiveCfg = Release|Any CPU
+		{7C9B9E2C-E927-46FD-8723-8072747C0873}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Tests/AssemblyWithoutReferenceTests.cs
+++ b/Tests/AssemblyWithoutReferenceTests.cs
@@ -1,0 +1,14 @@
+﻿using Fody;
+using Xunit;
+
+namespace Tests
+{
+    public class AssemblyWithoutReferenceTests
+    {
+        [Fact]
+        public void When_assembly_to_weave_does_not_reference_equals_assembly_weaving_should_not_fail()
+        {
+            var exception = Assert.Throws<WeavingException>(() => new ModuleWeaver().ExecuteTestRun("AssemblyToProcessWithoutReference.dll"));
+        }
+    }
+}

--- a/Tests/AssemblyWithoutReferenceTests.cs
+++ b/Tests/AssemblyWithoutReferenceTests.cs
@@ -6,6 +6,8 @@ public class AssemblyWithoutReferenceTests
     [Fact]
     public void When_assembly_to_weave_does_not_reference_equals_assembly_weaving_should_not_fail()
     {
-        var exception = Assert.Throws<WeavingException>(() => new ModuleWeaver().ExecuteTestRun("AssemblyToProcessWithoutReference.dll"));
+        var testResult = new ModuleWeaver().ExecuteTestRun("AssemblyToProcessWithoutReference.dll");
+
+        Assert.NotNull(testResult.GetInstance("Foo"));
     }
 }

--- a/Tests/AssemblyWithoutReferenceTests.cs
+++ b/Tests/AssemblyWithoutReferenceTests.cs
@@ -1,14 +1,11 @@
 ﻿using Fody;
 using Xunit;
 
-namespace Tests
+public class AssemblyWithoutReferenceTests
 {
-    public class AssemblyWithoutReferenceTests
+    [Fact]
+    public void When_assembly_to_weave_does_not_reference_equals_assembly_weaving_should_not_fail()
     {
-        [Fact]
-        public void When_assembly_to_weave_does_not_reference_equals_assembly_weaving_should_not_fail()
-        {
-            var exception = Assert.Throws<WeavingException>(() => new ModuleWeaver().ExecuteTestRun("AssemblyToProcessWithoutReference.dll"));
-        }
+        var exception = Assert.Throws<WeavingException>(() => new ModuleWeaver().ExecuteTestRun("AssemblyToProcessWithoutReference.dll"));
     }
 }

--- a/Tests/BadCaseIntegrationTests.cs
+++ b/Tests/BadCaseIntegrationTests.cs
@@ -3,7 +3,7 @@ using Xunit;
 
 public class OperatorBadCaseIntegrationTests
 {
-    ModuleWeaver weavingTask;
+    readonly ModuleWeaver weavingTask;
 
     public OperatorBadCaseIntegrationTests()
     {

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -18,5 +18,6 @@
     <ProjectReference Include="..\Equals.Fody\Equals.Fody.csproj" />
     <ProjectReference Include="..\Equals\Equals.csproj" />
     <ProjectReference Include="..\AssemblyToProcess\AssemblyToProcess.csproj" />
+    <ProjectReference Include="..\AssemblyToProcessWithoutReference\AssemblyToProcessWithoutReference.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
#### Description

This fixes #103.

#### The solution

When the assembly to be woven does not reference `Equals` (the assembly containing the `[Equals]` attribute etc.) weaving for this assembly is skipped.
See [here](https://github.com/Fody/Equals/pull/104/files#diff-44b258515829837514f65fe283c8f054R38).

Increased version to 3.0.2

#### Todos

 * [x] Related issues (#103)
 * [x] Tests (see [here](https://github.com/Fody/Equals/pull/104/files#diff-6fcf56426b7819c2de5dbf390dcecbc5R7))
 * [x] Documentation - **none** since it's the expected behavior and we don't keep a separate release notes document.