### PR TITLE
Added `DevelopmentDependency=true` to Equals.Fody project

### DIFF
--- a/Equals.Fody/Equals.Fody.csproj
+++ b/Equals.Fody/Equals.Fody.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <DebugType>portable</DebugType>
+    <DevelopmentDependency>true</DevelopmentDependency>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FodyHelpers" Version="6.5.2" />


### PR DESCRIPTION
This change automatically installs private assets after the package is installed.
Will be:
```xml
<PackageReference Include="Equals.Fody" Version="4.0.1">
   <PrivateAssets>all</PrivateAssets>
   <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
</PackageReference>
```
Instead:
```xml
<PackageReference Include="Equals.Fody" Version="4.0.1" />
```